### PR TITLE
chore: add podAffinity and labels to identify the pipeline

### DIFF
--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -115,7 +115,7 @@ func stepLabel(step *types.Step) (string, error) {
 	return toDNSName(step.Name)
 }
 
-func makeEnvtoLabels(m map[string]string) map[string]string {
+func mapEnvToLabels(m map[string]string) map[string]string {
 	labels := make(map[string]string)
   if val, ok := m["CI_REPO_NAME"]; ok {
     labels["repository"] = val

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -130,7 +130,7 @@ func podSpec(step *types.Step, config *config, labels map[string]string) (v1.Pod
 	var err error
 	spec := v1.PodSpec{}
 
-	// force service and steps run in the same node, when rwx is false
+	// force service and steps to run in the same node when rwx is false
 	// maybe in the future get theses values from backend configuration
 	if !config.StorageRwx {
 		spec.Affinity = &v1.Affinity{

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -93,7 +93,7 @@ func podMeta(step *types.Step, config *config, podName string) (metav1.ObjectMet
 		meta.Labels[ServiceLabel] = step.Name
 	}
 
-	maps.Copy(meta.Labels, makeEnvtoLabels(step.Environment))
+	maps.Copy(meta.Labels, mapEnvToLabels(step.Environment))
 
 	meta.Annotations = config.PodAnnotations
 	if meta.Annotations == nil {

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -117,14 +117,12 @@ func stepLabel(step *types.Step) (string, error) {
 
 func makeEnvtoLabels(m map[string]string) map[string]string {
 	labels := make(map[string]string)
-	for k, v := range m {
-		if strings.Contains(k, "CI_REPO_NAME") {
-			labels["repository"] = v
-		}
-		if strings.Contains(k, "CI_PIPELINE_NUMBER") {
-			labels["pipeline_number"] = v
-		}
-	}
+  if val, ok := m["CI_REPO_NAME"]; ok {
+    labels["repository"] = val
+  }
+  if val, ok := m["CI_PIPELINE_NUMBER"]; ok {
+    labels["pipeline_number"] = val
+  }
 	return labels
 }
 

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -124,9 +124,12 @@ func podSpec(step *types.Step, config *config, labels map[string]string) (v1.Pod
 	var err error
 	spec := v1.PodSpec{}
 
+	repoLabel, hasLabelRepo := labels["repository"]
+	pipelineNumberLabel, hasLabelPipelineNumber := labels["pipeline_number"]
+
 	// force service and steps to run in the same node when rwx is false
 	// maybe in the future get theses values from backend configuration
-	if !config.StorageRwx {
+	if !config.StorageRwx && hasLabelRepo && hasLabelPipelineNumber {
 		spec.Affinity = &v1.Affinity{
 			PodAffinity: &v1.PodAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
@@ -136,12 +139,12 @@ func podSpec(step *types.Step, config *config, labels map[string]string) (v1.Pod
 								{
 									Key:      "repository",
 									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{labels["repository"]},
+									Values:   []string{repoLabel},
 								},
 								{
 									Key:      "pipeline_number",
 									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{labels["pipeline_number"]},
+									Values:   []string{pipelineNumberLabel},
 								},
 							},
 						},

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -136,24 +136,26 @@ func podSpec(step *types.Step, config *config, labels map[string]string) (v1.Pod
 	// maybe in the future get theses values from backend configuration
 	if !config.StorageRwx {
 		spec.Affinity = &v1.Affinity{
-			PodAffinity: &v1.PodAffinity{RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
-				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "repository",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{labels["repository"]},
-							},
-							{
-								Key:      "pipeline_number",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{labels["pipeline_number"]},
+			PodAffinity: &v1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "repository",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{labels["repository"]},
+								},
+								{
+									Key:      "pipeline_number",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{labels["pipeline_number"]},
+								},
 							},
 						},
+						TopologyKey: "kubernetes.io/hostname",
 					},
-					TopologyKey: "kubernetes.io/hostname"},
-			},
+				},
 			},
 		}
 	}

--- a/pipeline/backend/kubernetes/pod.go
+++ b/pipeline/backend/kubernetes/pod.go
@@ -93,7 +93,12 @@ func podMeta(step *types.Step, config *config, podName string) (metav1.ObjectMet
 		meta.Labels[ServiceLabel] = step.Name
 	}
 
-	maps.Copy(meta.Labels, mapEnvToLabels(step.Environment))
+	if val, ok := step.Environment["CI_REPO_NAME"]; ok {
+		meta.Labels["repository"] = val
+	}
+	if val, ok := step.Environment["CI_PIPELINE_NUMBER"]; ok {
+		meta.Labels["pipeline_number"] = val
+	}
 
 	meta.Annotations = config.PodAnnotations
 	if meta.Annotations == nil {
@@ -113,17 +118,6 @@ func podMeta(step *types.Step, config *config, podName string) (metav1.ObjectMet
 
 func stepLabel(step *types.Step) (string, error) {
 	return toDNSName(step.Name)
-}
-
-func mapEnvToLabels(m map[string]string) map[string]string {
-	labels := make(map[string]string)
-  if val, ok := m["CI_REPO_NAME"]; ok {
-    labels["repository"] = val
-  }
-  if val, ok := m["CI_PIPELINE_NUMBER"]; ok {
-    labels["pipeline_number"] = val
-  }
-	return labels
 }
 
 func podSpec(step *types.Step, config *config, labels map[string]string) (v1.PodSpec, error) {


### PR DESCRIPTION
# Why 

We run with storage `rwx` set as `false`. 
When we ran a step like a service the PVC was locked by the first step of the pipeline and the other steps got stuck trying to mount the PVC.

The idea is to force PodAffinty to run in the same node when `rwx` is `false`. 


![image](https://github.com/quintoandar/woodpecker/assets/22245125/8ba1caeb-6ab2-4491-a601-2c9771ec3364)
