### PR TITLE
Attempt to fix agents CPU lock and log parsing

### DIFF
--- a/agent/rpc/client_grpc.go
+++ b/agent/rpc/client_grpc.go
@@ -97,7 +97,6 @@ func (c *client) Next(ctx context.Context, f rpc.Filter) (*rpc.Workflow, error) 
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -143,7 +142,6 @@ func (c *client) Wait(ctx context.Context, id string) (err error) {
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -184,7 +182,6 @@ func (c *client) Init(ctx context.Context, id string, state rpc.State) (err erro
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -225,7 +222,6 @@ func (c *client) Done(ctx context.Context, id string, state rpc.State) (err erro
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -259,7 +255,6 @@ func (c *client) Extend(ctx context.Context, id string) (err error) {
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -300,7 +295,6 @@ func (c *client) Update(ctx context.Context, id string, state rpc.State) (err er
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:
@@ -385,7 +379,6 @@ func (c *client) ReportHealth(ctx context.Context) (err error) {
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:

--- a/agent/rpc/client_grpc.go
+++ b/agent/rpc/client_grpc.go
@@ -339,7 +339,6 @@ func (c *client) Log(ctx context.Context, logEntry *rpc.LogEntry) (err error) {
 			codes.Aborted,
 			codes.DataLoss,
 			codes.DeadlineExceeded,
-			codes.Internal,
 			codes.Unavailable:
 			// non-fatal errors
 		default:

--- a/pipeline/rpc/log_entry.go
+++ b/pipeline/rpc/log_entry.go
@@ -88,7 +88,11 @@ func (w *LineWriter) Write(p []byte) (n int, err error) {
 		Type:     LogEntryStdout,
 		Line:     w.num,
 	}
-	if err := w.peer.Log(context.Background(), line); err != nil {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := w.peer.Log(ctx, line); err != nil {
 		log.Error().Err(err).Str("step-uuid", w.stepUUID).Msg("fail to write pipeline log to peer")
 	}
 	w.num++

--- a/pipeline/rpc/log_entry.go
+++ b/pipeline/rpc/log_entry.go
@@ -89,7 +89,7 @@ func (w *LineWriter) Write(p []byte) (n int, err error) {
 		Line:     w.num,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := w.peer.Log(ctx, line); err != nil {


### PR DESCRIPTION
We have observed several issues that may be related:

1. Agents behave erractly when dealing with certain log payloads. A common observation here is that steps that produce a large volume of logs will cause some steps to be stuck "pending" forever.

2. Agents use way more CPU than should be expected, we often see 200-300 millicores of CPU per Workflow per agent.

3. We commonly see Agents displaying thousands of error lines such as those, often with the same timestamp, indicating an error with parsing logs and attempting to perform GRPC requests, which may explain issues 1 and 2.

```
{"level":"error","error":"rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8","time":"2024-04-05T21:32:25Z","caller":"/src/agent/rpc/client_grpc.go:335","message":"grpc error: log(): code: Internal"}
{"level":"error","error":"rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8","time":"2024-04-05T21:32:25Z","caller":"/src/agent/rpc/client_grpc.go:335","message":"grpc error: log(): code: Internal"}
{"level":"error","error":"rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8","time":"2024-04-05T21:32:25Z","caller":"/src/agent/rpc/client_grpc.go:335","message":"grpc error: log(): code: Internal"}
```

4. We've also observed that agents will sometimes "drop out" of the worker queue, as we often seem to have less active workers than we should as observed by both the `woodpecker_worker_count` and the actual maximum number of tasks.

Seeing that the issue points to `client_grpc.go:335`, this pull request attempts to fix these problems by:

1. Removing codes.Internal from being a retryable GRPC status. Now agent GRPC calls that fail with codes.Internal (such as those above) will not be retried. I've searched and there's not an agreement on what GRPC codes should be retried but Internal does not seem to be a common one to retry anyway.

2. Add a timeout of 30 seconds to any retries. Currently, the exponential retries have a maximum timeout of _15 minutes_. I think this is behind the huge cpu increase as some pods might be locked forever retrying these requests. Of course, since we have completely removed the possibility of a retry for these particular error codes, this should not make any difference for this scenario... but hopefully will solve the issue for other similar potential scenarios.