### PR TITLE
chore: (quinto-local-setup) adds local setup

### DIFF
--- a/quinto-local-setup/.env.sample
+++ b/quinto-local-setup/.env.sample
@@ -1,0 +1,25 @@
+# host on which drone is hosted
+WOODPECKER_HOST=https://woodpecker.mycompany.com
+
+# use lets encrypt service to automatically generate tsl certificates for https access
+WOODPECKER_LETS_ENCRYPT=true
+
+# allow registrations only for users that are part of organization
+WOODPECKER_ORGS=
+
+# change <username> to GitHub username
+WOODPECKER_ADMIN=<username>
+
+# filter which GitHub user's repos should be synced only
+WOODPECKER_REPO_OWNERS=
+
+# GitHub Client ID of oauth app
+WOODPECKER_GITHUB_CLIENT_ID=
+
+# GitHub Client Secret of OAuth app
+WOODPECKER_GITHUB_CLIENT_SECRET=
+
+# change to any random string here. it is RPC secret key for drone to comuticate between server and agent
+WOODPECKER_RPC_SECRET=random-string-here
+
+CLOUDFLARED_TOKEN=cloudflared-tunnel-token

--- a/quinto-local-setup/.gitignore
+++ b/quinto-local-setup/.gitignore
@@ -1,0 +1,2 @@
+.env
+!docker-compose.yml

--- a/quinto-local-setup/README.md
+++ b/quinto-local-setup/README.md
@@ -1,0 +1,5 @@
+# Local setup
+
+ This folder contains files to host a local setup of woodpecker exposed with the use of [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/). The folder's name is prefixed with "quinto" to discern it from the files and folders from the upstream woodpecker OSS repository.
+
+ This was heavily inspired by devforth's woodpecker compose template ([MIT licensed](https://github.com/devforth/woodpecker-compose-template/blob/73072e0e49c2b502b477016c729a833aa4f8a17a/LICENSE)).

--- a/quinto-local-setup/docker-compose-cloudflare.yml
+++ b/quinto-local-setup/docker-compose-cloudflare.yml
@@ -1,0 +1,9 @@
+services:
+  cloudflare-tunnel:
+    image: cloudflare/cloudflared:latest
+    command: ["tunnel", "--no-autoupdate", "run"]
+    environment:
+      - NO_AUTOUPDATE=true
+      - TUNNEL_TOKEN=${CLOUDFLARED_TOKEN}
+    networks:
+      - woodpecker

--- a/quinto-local-setup/docker-compose-woodpecker.yml
+++ b/quinto-local-setup/docker-compose-woodpecker.yml
@@ -1,0 +1,57 @@
+# References:
+# - https://github.com/devforth/woodpecker-compose-template/blob/master/docker-compose.yml
+# - https://woodpecker-ci.org/docs/administration/installation/docker-compose
+
+services:
+  woodpecker-server:
+    image: woodpeckerci/woodpecker-server:v3.9.0
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - woodpecker
+    volumes:
+      - woodpecker-server-data:/var/lib/woodpecker/
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: always
+    environment:
+      - WOODPECKER_OPEN=false
+      - WOODPECKER_GITHUB=true
+      - WOODPECKER_SERVER_ADDR=:80
+      - WOODPECKER_LETS_ENCRYPT=${WOODPECKER_LETS_ENCRYPT}
+      - WOODPECKER_HOST=${WOODPECKER_HOST}
+      - WOODPECKER_ADMIN=${WOODPECKER_ADMIN}
+      - WOODPECKER_ORGS=${WOODPECKER_ORGS}
+      - WOODPECKER_REPO_OWNERS=${WOODPECKER_REPO_OWNERS}
+      - WOODPECKER_GITHUB_CLIENT=${WOODPECKER_GITHUB_CLIENT_ID}
+      - WOODPECKER_GITHUB_SECRET=${WOODPECKER_GITHUB_CLIENT_SECRET}
+      - WOODPECKER_AGENT_SECRET="${WOODPECKER_RPC_SECRET}"
+
+      - WOODPECKER_DATABASE_DRIVER=sqlite3
+      - WOODPECKER_DATABASE_DATASOURCE=/var/lib/woodpecker/woodpecker.sqlite
+      - WOODPECKER_DEBUG=true
+
+  woodpecker-agent:
+    image: woodpeckerci/woodpecker-agent:v3.9.0
+    command: agent
+    restart: always
+    depends_on:
+      - woodpecker-server
+    networks:
+      - woodpecker
+    volumes:
+      - woodpecker-agent-config:/etc/woodpecker
+      - /var/run/docker.sock:/var/run/docker.sock
+
+    environment:
+      - WOODPECKER_AGENT_SECRET="${WOODPECKER_RPC_SECRET}"
+      - WOODPECKER_SERVER=woodpecker-server:9000
+      - WOODPECKER_DEBUG=true
+
+networks:
+  woodpecker:
+    name: woodpecker_network
+
+volumes:
+  woodpecker-server-data:
+  woodpecker-agent-config:

--- a/quinto-local-setup/docker-compose.yml
+++ b/quinto-local-setup/docker-compose.yml
@@ -1,0 +1,3 @@
+include:
+  - docker-compose-woodpecker.yml
+  - docker-compose-cloudflare.yml


### PR DESCRIPTION
Adds Docker-compose setup for local hosting of woodpecker, meant for testing

relates to https://quintoandar.atlassian.net/browse/PRDPLT-1148