### PR TITLE
fix: async webhook ack with sync timeout

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -99,6 +99,12 @@ var flags = append([]cli.Flag{
 		Name:    "custom-js-file",
 		Usage:   "file path for the server to serve a custom .JS file, used for customizing the UI",
 	},
+	&cli.DurationFlag{
+		Sources: cli.EnvVars("WOODPECKER_WEBHOOK_SYNC_TIMEOUT"),
+		Name:    "webhook-sync-timeout",
+		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 disables the fallback and always responds synchronously",
+		Value:   5 * time.Second,
+	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_GRPC_ADDR"),
 		Name:    "grpc-addr",

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -102,7 +102,7 @@ var flags = append([]cli.Flag{
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_WEBHOOK_SYNC_TIMEOUT"),
 		Name:    "webhook-sync-timeout",
-		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 disables the fallback and always responds synchronously",
+		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 waits for creation to finish before responding (still subject to the 2m background create cap)",
 		Value:   5 * time.Second,
 	},
 	&cli.StringFlag{

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -251,6 +251,7 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	server.Config.Server.RootPath = rootPath
 	server.Config.Server.CustomCSSFile = strings.TrimSpace(c.String("custom-css-file"))
 	server.Config.Server.CustomJsFile = strings.TrimSpace(c.String("custom-js-file"))
+	server.Config.Server.WebhookSyncTimeout = c.Duration("webhook-sync-timeout")
 	server.Config.Pipeline.Networks = c.StringSlice("network")
 	server.Config.Pipeline.Volumes = c.StringSlice("volume")
 	server.Config.WebUI.EnableSwagger = c.Bool("enable-swagger")

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -251,46 +251,50 @@ func PostHook(c *gin.Context) {
 	//
 	// 6. Finally create a pipeline
 	//
-	// Pipeline creation can be slow (forge round-trips, config fetching). To
-	// avoid the forge timing out and retrying the webhook delivery, we wait only
-	// up to WebhookSyncTimeout for creation to finish. If it completes in time we
-	// respond synchronously with the created pipeline (preserving the old
-	// behavior and API response). If it takes longer we respond 202 Accepted and
-	// let creation finish in the background.
-	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), backgroundPipelineCreationTimeout)
+	respondWebhookPipelineCreate(c, _store, repo, pipelineFromForge)
+}
+
+// respondWebhookPipelineCreate runs pipeline.Create with a hybrid sync/async ack:
+// wait up to WebhookSyncTimeout, then either respond with the create result or
+// return 202 Accepted and finish creation in the background.
+func respondWebhookPipelineCreate(c *gin.Context, _store store.Store, repo *model.Repo, pipelineFromForge *model.Pipeline) {
+	bgCtx, cancel := context.WithTimeout(context.Background(), backgroundPipelineCreationTimeout)
 
 	done := make(chan pipelineCreateResult, 1)
 	go func() {
 		defer cancel()
 		pl, createErr := pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
-		if createErr != nil {
-			log.Error().Err(createErr).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
-		}
 		done <- pipelineCreateResult{pipeline: pl, err: createErr}
 	}()
 
+	var result pipelineCreateResult
 	syncTimeout := server.Config.Server.WebhookSyncTimeout
 	if syncTimeout > 0 {
 		select {
-		case result := <-done:
-			if result.err != nil {
-				handlePipelineErr(c, result.err)
-			} else {
-				c.JSON(http.StatusOK, result.pipeline)
-			}
+		case result = <-done:
 		case <-time.After(syncTimeout):
 			log.Debug().Str("repo", repo.FullName).Dur("timeout", syncTimeout).Msg("pipeline creation exceeded webhook sync timeout, continuing in background")
 			c.JSON(http.StatusAccepted, nil)
+			go logBackgroundWebhookCreate(repo.FullName, done)
+			return
 		}
-		return
+	} else {
+		result = <-done
 	}
 
-	result := <-done
 	if result.err != nil {
 		handlePipelineErr(c, result.err)
-	} else {
-		c.JSON(http.StatusOK, result.pipeline)
+		return
 	}
+	c.JSON(http.StatusOK, result.pipeline)
+}
+
+func logBackgroundWebhookCreate(repoFullName string, done <-chan pipelineCreateResult) {
+	result := <-done
+	if result.err == nil || errors.Is(result.err, pipeline.ErrFiltered) {
+		return
+	}
+	log.Error().Err(result.err).Str("repo", repoFullName).Msg("could not create pipeline from webhook")
 }
 
 func getRepoFromToken(store store.Store, t *token.Token) (*model.Repo, error) {

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -17,10 +17,12 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -33,6 +35,17 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/token"
 )
+
+// backgroundPipelineCreationTimeout caps how long a webhook-triggered pipeline
+// creation may keep running after the HTTP handler has already responded 202
+// Accepted (see PostHook). It bounds the detached background goroutine so a
+// stuck creation cannot leak indefinitely.
+const backgroundPipelineCreationTimeout = 2 * time.Minute
+
+type pipelineCreateResult struct {
+	pipeline *model.Pipeline
+	err      error
+}
 
 // GetQueueInfo
 //
@@ -238,12 +251,45 @@ func PostHook(c *gin.Context) {
 	//
 	// 6. Finally create a pipeline
 	//
+	// Pipeline creation can be slow (forge round-trips, config fetching). To
+	// avoid the forge timing out and retrying the webhook delivery, we wait only
+	// up to WebhookSyncTimeout for creation to finish. If it completes in time we
+	// respond synchronously with the created pipeline (preserving the old
+	// behavior and API response). If it takes longer we respond 202 Accepted and
+	// let creation finish in the background.
+	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), backgroundPipelineCreationTimeout)
 
-	pl, err := pipeline.Create(c, _store, repo, pipelineFromForge)
-	if err != nil {
-		handlePipelineErr(c, err)
+	done := make(chan pipelineCreateResult, 1)
+	go func() {
+		defer cancel()
+		pl, createErr := pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
+		if createErr != nil {
+			log.Error().Err(createErr).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
+		}
+		done <- pipelineCreateResult{pipeline: pl, err: createErr}
+	}()
+
+	syncTimeout := server.Config.Server.WebhookSyncTimeout
+	if syncTimeout > 0 {
+		select {
+		case result := <-done:
+			if result.err != nil {
+				handlePipelineErr(c, result.err)
+			} else {
+				c.JSON(http.StatusOK, result.pipeline)
+			}
+		case <-time.After(syncTimeout):
+			log.Debug().Str("repo", repo.FullName).Dur("timeout", syncTimeout).Msg("pipeline creation exceeded webhook sync timeout, continuing in background")
+			c.JSON(http.StatusAccepted, nil)
+		}
+		return
+	}
+
+	result := <-done
+	if result.err != nil {
+		handlePipelineErr(c, result.err)
 	} else {
-		c.JSON(http.StatusOK, pl)
+		c.JSON(http.StatusOK, result.pipeline)
 	}
 }
 

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -1,17 +1,3 @@
-// Copyright 2024 Woodpecker Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api_test
 
 import (

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -29,152 +29,125 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/shared/token"
 )
 
-func TestHook(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	_secretService := mocks_secret_service.NewService(t)
-	_registryService := mocks_registry_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 0 // fully synchronous for this test
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-	user := &model.User{
-		ID: 123,
-	}
-	repo := &model.Repo{
-		ID:            123,
-		ForgeRemoteID: "123",
-		Owner:         "owner",
-		Name:          "name",
-		IsActive:      true,
-		UserID:        user.ID,
-		Hash:          "secret-123-this-is-a-secret",
-	}
-	pipeline := &model.Pipeline{
-		ID:     123,
-		RepoID: repo.ID,
-		Event:  model.EventPush,
-	}
-
-	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
-	assert.NoError(t, err)
-
-	header := http.Header{}
-	header.Set("Authorization", fmt.Sprintf("Bearer %s", signedToken))
-	c.Request = &http.Request{
-		Header: header,
-		URL: &url.URL{
-			Scheme: "https",
-		},
-	}
-
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	_forge.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{}, nil)
-	_store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	_manager.On("SecretServiceFromRepo", repo).Return(_secretService)
-	_secretService.On("SecretListPipeline", repo, mock.Anything, mock.Anything).Return(nil, nil)
-	_manager.On("RegistryServiceFromRepo", repo).Return(_registryService)
-	_registryService.On("RegistryListPipeline", repo, mock.Anything).Return(nil, nil)
-	_manager.On("EnvironmentService").Return(nil)
-	_store.On("DeletePipeline", mock.Anything).Return(nil)
-
-	api.PostHook(c)
-
-	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
-	assert.Equal(t, "true", w.Header().Get("Pipeline-Filtered"))
+type hookFixture struct {
+	c              *gin.Context
+	w              *httptest.ResponseRecorder
+	manager        *mocks_services.Manager
+	forge          *mocks_forge.Forge
+	store          *mocks_store.Store
+	configService  *mocks_config_service.Service
+	user           *model.User
+	repo           *model.Repo
+	pipeline       *model.Pipeline
 }
 
-func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+func newHookFixture(t *testing.T, syncTimeout time.Duration) *hookFixture {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 50 * time.Millisecond
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-
-	user := &model.User{ID: 123}
-	repo := &model.Repo{
+	f := &hookFixture{
+		manager:       mocks_services.NewManager(t),
+		forge:         mocks_forge.NewForge(t),
+		store:         mocks_store.NewStore(t),
+		configService: mocks_config_service.NewService(t),
+		w:             httptest.NewRecorder(),
+		user:          &model.User{ID: 123},
+	}
+	f.repo = &model.Repo{
 		ID:            123,
 		ForgeRemoteID: "123",
 		Owner:         "owner",
 		Name:          "name",
 		FullName:      "owner/name",
 		IsActive:      true,
-		UserID:        user.ID,
+		UserID:        f.user.ID,
 		Hash:          "secret-123-this-is-a-secret",
 	}
-	pipeline := &model.Pipeline{
+	f.pipeline = &model.Pipeline{
 		ID:     123,
-		RepoID: repo.ID,
+		RepoID: f.repo.ID,
 		Event:  model.EventPush,
 	}
 
+	server.Config.Services.Manager = f.manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = syncTimeout
+
+	f.c, _ = gin.CreateTestContext(f.w)
+	f.c.Set("store", f.store)
+
 	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	repoToken.Set("repo-id", fmt.Sprintf("%d", f.repo.ID))
+	signedToken, err := repoToken.Sign(f.repo.Hash)
 	require.NoError(t, err)
 
-	c.Request = &http.Request{
+	f.c.Request = &http.Request{
 		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
 		URL:    &url.URL{Scheme: "https"},
 	}
+
+	f.manager.On("ForgeFromRepo", f.repo).Return(f.forge, nil)
+	f.forge.On("Hook", mock.Anything, mock.Anything).Return(f.repo, f.pipeline, nil)
+	f.store.On("GetRepo", f.repo.ID).Return(f.repo, nil)
+	f.store.On("GetUser", f.user.ID).Return(f.user, nil)
+	f.store.On("UpdateRepo", f.repo).Return(nil)
+	f.store.On("CreatePipeline", mock.Anything).Return(nil)
+	f.manager.On("ConfigServiceFromRepo", f.repo).Return(f.configService)
+
+	return f
+}
+
+func (f *hookFixture) expectFilteredCreatePath(t *testing.T) {
+	t.Helper()
+	secretService := mocks_secret_service.NewService(t)
+	registryService := mocks_registry_service.NewService(t)
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	f.forge.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{}, nil)
+	f.store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	f.manager.On("SecretServiceFromRepo", f.repo).Return(secretService)
+	secretService.On("SecretListPipeline", f.repo, mock.Anything, mock.Anything).Return(nil, nil)
+	f.manager.On("RegistryServiceFromRepo", f.repo).Return(registryService)
+	registryService.On("RegistryListPipeline", f.repo, mock.Anything).Return(nil, nil)
+	f.manager.On("EnvironmentService").Return(nil)
+	f.store.On("DeletePipeline", mock.Anything).Return(nil)
+}
+
+func TestHook(t *testing.T) {
+	f := newHookFixture(t, 0) // fully wait for create before responding
+	f.expectFilteredCreatePath(t)
+
+	api.PostHook(f.c)
+
+	assert.Equal(t, http.StatusNoContent, f.c.Writer.Status())
+	assert.Equal(t, "true", f.w.Header().Get("Pipeline-Filtered"))
+}
+
+func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+	f := newHookFixture(t, 50*time.Millisecond)
 
 	var fetchStarted sync.WaitGroup
 	fetchStarted.Add(1)
 	createDone := make(chan struct{})
 
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			fetchStarted.Done()
-			// Block long enough that the sync timeout fires, then finish.
 			time.Sleep(200 * time.Millisecond)
 		}).
 		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
-	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+	f.store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
 		close(createDone)
 	}).Return(nil)
 
 	start := time.Now()
-	api.PostHook(c)
+	api.PostHook(f.c)
 	elapsed := time.Since(start)
 
-	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Equal(t, http.StatusAccepted, f.c.Writer.Status())
 	assert.Less(t, elapsed, 150*time.Millisecond, "handler should return soon after sync timeout")
 
-	// Background create must still run (Fetch was started) and complete.
 	fetchStarted.Wait()
 	select {
 	case <-createDone:
@@ -184,65 +157,19 @@ func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
 }
 
 func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 30 * time.Millisecond
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-
-	user := &model.User{ID: 123}
-	repo := &model.Repo{
-		ID:            123,
-		ForgeRemoteID: "123",
-		Owner:         "owner",
-		Name:          "name",
-		FullName:      "owner/name",
-		IsActive:      true,
-		UserID:        user.ID,
-		Hash:          "secret-123-this-is-a-secret",
-	}
-	pipeline := &model.Pipeline{
-		ID:     123,
-		RepoID: repo.ID,
-		Event:  model.EventPush,
-	}
-
-	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
-	require.NoError(t, err)
+	f := newHookFixture(t, 30*time.Millisecond)
 
 	reqCtx, reqCancel := context.WithCancel(context.Background())
-	c.Request = (&http.Request{
-		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
-		URL:    &url.URL{Scheme: "https"},
-	}).WithContext(reqCtx)
+	f.c.Request = f.c.Request.WithContext(reqCtx)
 
 	var sawLiveCtx sync.WaitGroup
 	sawLiveCtx.Add(1)
 	createDone := make(chan struct{})
 
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			ctx := args.Get(0).(context.Context)
-			reqCancel() // cancel the HTTP request context while Fetch is in flight
+			reqCancel()
 			select {
 			case <-ctx.Done():
 				t.Errorf("background create context was cancelled by request end")
@@ -251,12 +178,12 @@ func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
 			}
 		}).
 		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
-	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+	f.store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
 		close(createDone)
 	}).Return(nil)
 
-	api.PostHook(c)
-	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	api.PostHook(f.c)
+	assert.Equal(t, http.StatusAccepted, f.c.Writer.Status())
 
 	sawLiveCtx.Wait()
 	select {

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -1,19 +1,38 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/api"
 	mocks_forge "go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	mocks_config_service "go.woodpecker-ci.org/woodpecker/v3/server/services/config/mocks"
 	mocks_services "go.woodpecker-ci.org/woodpecker/v3/server/services/mocks"
@@ -37,6 +56,7 @@ func TestHook(t *testing.T) {
 	server.Config.Permissions.Open = true
 	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
 	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 0 // fully synchronous for this test
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Set("store", _store)
@@ -93,4 +113,169 @@ func TestHook(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
 	assert.Equal(t, "true", w.Header().Get("Pipeline-Filtered"))
+}
+
+func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	_manager := mocks_services.NewManager(t)
+	_forge := mocks_forge.NewForge(t)
+	_store := mocks_store.NewStore(t)
+	_configService := mocks_config_service.NewService(t)
+	server.Config.Services.Manager = _manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 50 * time.Millisecond
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("store", _store)
+
+	user := &model.User{ID: 123}
+	repo := &model.Repo{
+		ID:            123,
+		ForgeRemoteID: "123",
+		Owner:         "owner",
+		Name:          "name",
+		FullName:      "owner/name",
+		IsActive:      true,
+		UserID:        user.ID,
+		Hash:          "secret-123-this-is-a-secret",
+	}
+	pipeline := &model.Pipeline{
+		ID:     123,
+		RepoID: repo.ID,
+		Event:  model.EventPush,
+	}
+
+	repoToken := token.New(token.HookToken)
+	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
+	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	require.NoError(t, err)
+
+	c.Request = &http.Request{
+		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
+		URL:    &url.URL{Scheme: "https"},
+	}
+
+	var fetchStarted sync.WaitGroup
+	fetchStarted.Add(1)
+	createDone := make(chan struct{})
+
+	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
+	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
+	_store.On("GetRepo", repo.ID).Return(repo, nil)
+	_store.On("GetUser", user.ID).Return(user, nil)
+	_store.On("UpdateRepo", repo).Return(nil)
+	_store.On("CreatePipeline", mock.Anything).Return(nil)
+	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
+	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			fetchStarted.Done()
+			// Block long enough that the sync timeout fires, then finish.
+			time.Sleep(200 * time.Millisecond)
+		}).
+		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
+	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+		close(createDone)
+	}).Return(nil)
+
+	start := time.Now()
+	api.PostHook(c)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Less(t, elapsed, 150*time.Millisecond, "handler should return soon after sync timeout")
+
+	// Background create must still run (Fetch was started) and complete.
+	fetchStarted.Wait()
+	select {
+	case <-createDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background pipeline create did not finish")
+	}
+}
+
+func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	_manager := mocks_services.NewManager(t)
+	_forge := mocks_forge.NewForge(t)
+	_store := mocks_store.NewStore(t)
+	_configService := mocks_config_service.NewService(t)
+	server.Config.Services.Manager = _manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 30 * time.Millisecond
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("store", _store)
+
+	user := &model.User{ID: 123}
+	repo := &model.Repo{
+		ID:            123,
+		ForgeRemoteID: "123",
+		Owner:         "owner",
+		Name:          "name",
+		FullName:      "owner/name",
+		IsActive:      true,
+		UserID:        user.ID,
+		Hash:          "secret-123-this-is-a-secret",
+	}
+	pipeline := &model.Pipeline{
+		ID:     123,
+		RepoID: repo.ID,
+		Event:  model.EventPush,
+	}
+
+	repoToken := token.New(token.HookToken)
+	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
+	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	require.NoError(t, err)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	c.Request = (&http.Request{
+		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
+		URL:    &url.URL{Scheme: "https"},
+	}).WithContext(reqCtx)
+
+	var sawLiveCtx sync.WaitGroup
+	sawLiveCtx.Add(1)
+	createDone := make(chan struct{})
+
+	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
+	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
+	_store.On("GetRepo", repo.ID).Return(repo, nil)
+	_store.On("GetUser", user.ID).Return(user, nil)
+	_store.On("UpdateRepo", repo).Return(nil)
+	_store.On("CreatePipeline", mock.Anything).Return(nil)
+	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
+	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			reqCancel() // cancel the HTTP request context while Fetch is in flight
+			select {
+			case <-ctx.Done():
+				t.Errorf("background create context was cancelled by request end")
+			case <-time.After(80 * time.Millisecond):
+				sawLiveCtx.Done()
+			}
+		}).
+		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
+	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+		close(createDone)
+	}).Return(nil)
+
+	api.PostHook(c)
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+
+	sawLiveCtx.Wait()
+	select {
+	case <-createDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background pipeline create did not finish")
+	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -53,6 +53,7 @@ var Config = struct {
 		RootPath            string
 		CustomCSSFile       string
 		CustomJsFile        string
+		WebhookSyncTimeout  time.Duration
 	}
 	Agent struct {
 		DisableUserRegisteredAgentRegistration bool

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -88,7 +88,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, ErrFiltered
 	} else if configFetchErr != nil {
 		log.Error().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
-		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", err))
+		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", configFetchErr))
 	}
 
 	pipelineItems, parseErr := parsePipeline(_forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Backport upstream hybrid webhook handling: wait up to `WOODPECKER_WEBHOOK_SYNC_TIMEOUT` (default 5s) for `pipeline.Create`, then respond **202 Accepted** and finish creation in a detached background context (2m cap).
- Single response path via `respondWebhookPipelineCreate`; background failures logged only after 202 (skips `ErrFiltered`).
- Fix `pipeline.Create` wrapping the wrong error (`err` → `configFetchErr`) on forge config fetch failure.