### PR TITLE
fix: fetch github config dir via graphql

### DIFF
--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -99,6 +99,12 @@ var flags = append([]cli.Flag{
 		Name:    "custom-js-file",
 		Usage:   "file path for the server to serve a custom .JS file, used for customizing the UI",
 	},
+	&cli.DurationFlag{
+		Sources: cli.EnvVars("WOODPECKER_WEBHOOK_SYNC_TIMEOUT"),
+		Name:    "webhook-sync-timeout",
+		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 disables the fallback and always responds synchronously",
+		Value:   5 * time.Second,
+	},
 	&cli.StringFlag{
 		Sources: cli.EnvVars("WOODPECKER_GRPC_ADDR"),
 		Name:    "grpc-addr",

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -102,7 +102,7 @@ var flags = append([]cli.Flag{
 	&cli.DurationFlag{
 		Sources: cli.EnvVars("WOODPECKER_WEBHOOK_SYNC_TIMEOUT"),
 		Name:    "webhook-sync-timeout",
-		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 disables the fallback and always responds synchronously",
+		Usage:   "max time to wait for pipeline creation triggered by an incoming webhook before responding 202 Accepted and finishing it in the background; 0 waits for creation to finish before responding (still subject to the 2m background create cap)",
 		Value:   5 * time.Second,
 	},
 	&cli.StringFlag{

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -251,6 +251,7 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	server.Config.Server.RootPath = rootPath
 	server.Config.Server.CustomCSSFile = strings.TrimSpace(c.String("custom-css-file"))
 	server.Config.Server.CustomJsFile = strings.TrimSpace(c.String("custom-js-file"))
+	server.Config.Server.WebhookSyncTimeout = c.Duration("webhook-sync-timeout")
 	server.Config.Pipeline.Networks = c.StringSlice("network")
 	server.Config.Pipeline.Volumes = c.StringSlice("volume")
 	server.Config.WebUI.EnableSwagger = c.Bool("enable-swagger")

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -251,46 +251,50 @@ func PostHook(c *gin.Context) {
 	//
 	// 6. Finally create a pipeline
 	//
-	// Pipeline creation can be slow (forge round-trips, config fetching). To
-	// avoid the forge timing out and retrying the webhook delivery, we wait only
-	// up to WebhookSyncTimeout for creation to finish. If it completes in time we
-	// respond synchronously with the created pipeline (preserving the old
-	// behavior and API response). If it takes longer we respond 202 Accepted and
-	// let creation finish in the background.
-	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), backgroundPipelineCreationTimeout)
+	respondWebhookPipelineCreate(c, _store, repo, pipelineFromForge)
+}
+
+// respondWebhookPipelineCreate runs pipeline.Create with a hybrid sync/async ack:
+// wait up to WebhookSyncTimeout, then either respond with the create result or
+// return 202 Accepted and finish creation in the background.
+func respondWebhookPipelineCreate(c *gin.Context, _store store.Store, repo *model.Repo, pipelineFromForge *model.Pipeline) {
+	bgCtx, cancel := context.WithTimeout(context.Background(), backgroundPipelineCreationTimeout)
 
 	done := make(chan pipelineCreateResult, 1)
 	go func() {
 		defer cancel()
 		pl, createErr := pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
-		if createErr != nil {
-			log.Error().Err(createErr).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
-		}
 		done <- pipelineCreateResult{pipeline: pl, err: createErr}
 	}()
 
+	var result pipelineCreateResult
 	syncTimeout := server.Config.Server.WebhookSyncTimeout
 	if syncTimeout > 0 {
 		select {
-		case result := <-done:
-			if result.err != nil {
-				handlePipelineErr(c, result.err)
-			} else {
-				c.JSON(http.StatusOK, result.pipeline)
-			}
+		case result = <-done:
 		case <-time.After(syncTimeout):
 			log.Debug().Str("repo", repo.FullName).Dur("timeout", syncTimeout).Msg("pipeline creation exceeded webhook sync timeout, continuing in background")
 			c.JSON(http.StatusAccepted, nil)
+			go logBackgroundWebhookCreate(repo.FullName, done)
+			return
 		}
-		return
+	} else {
+		result = <-done
 	}
 
-	result := <-done
 	if result.err != nil {
 		handlePipelineErr(c, result.err)
-	} else {
-		c.JSON(http.StatusOK, result.pipeline)
+		return
 	}
+	c.JSON(http.StatusOK, result.pipeline)
+}
+
+func logBackgroundWebhookCreate(repoFullName string, done <-chan pipelineCreateResult) {
+	result := <-done
+	if result.err == nil || errors.Is(result.err, pipeline.ErrFiltered) {
+		return
+	}
+	log.Error().Err(result.err).Str("repo", repoFullName).Msg("could not create pipeline from webhook")
 }
 
 func getRepoFromToken(store store.Store, t *token.Token) (*model.Repo, error) {

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -17,10 +17,12 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -33,6 +35,17 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 	"go.woodpecker-ci.org/woodpecker/v3/shared/token"
 )
+
+// backgroundPipelineCreationTimeout caps how long a webhook-triggered pipeline
+// creation may keep running after the HTTP handler has already responded 202
+// Accepted (see PostHook). It bounds the detached background goroutine so a
+// stuck creation cannot leak indefinitely.
+const backgroundPipelineCreationTimeout = 2 * time.Minute
+
+type pipelineCreateResult struct {
+	pipeline *model.Pipeline
+	err      error
+}
 
 // GetQueueInfo
 //
@@ -238,12 +251,45 @@ func PostHook(c *gin.Context) {
 	//
 	// 6. Finally create a pipeline
 	//
+	// Pipeline creation can be slow (forge round-trips, config fetching). To
+	// avoid the forge timing out and retrying the webhook delivery, we wait only
+	// up to WebhookSyncTimeout for creation to finish. If it completes in time we
+	// respond synchronously with the created pipeline (preserving the old
+	// behavior and API response). If it takes longer we respond 202 Accepted and
+	// let creation finish in the background.
+	bgCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), backgroundPipelineCreationTimeout)
 
-	pl, err := pipeline.Create(c, _store, repo, pipelineFromForge)
-	if err != nil {
-		handlePipelineErr(c, err)
+	done := make(chan pipelineCreateResult, 1)
+	go func() {
+		defer cancel()
+		pl, createErr := pipeline.Create(bgCtx, _store, repo, pipelineFromForge)
+		if createErr != nil {
+			log.Error().Err(createErr).Str("repo", repo.FullName).Msg("could not create pipeline from webhook")
+		}
+		done <- pipelineCreateResult{pipeline: pl, err: createErr}
+	}()
+
+	syncTimeout := server.Config.Server.WebhookSyncTimeout
+	if syncTimeout > 0 {
+		select {
+		case result := <-done:
+			if result.err != nil {
+				handlePipelineErr(c, result.err)
+			} else {
+				c.JSON(http.StatusOK, result.pipeline)
+			}
+		case <-time.After(syncTimeout):
+			log.Debug().Str("repo", repo.FullName).Dur("timeout", syncTimeout).Msg("pipeline creation exceeded webhook sync timeout, continuing in background")
+			c.JSON(http.StatusAccepted, nil)
+		}
+		return
+	}
+
+	result := <-done
+	if result.err != nil {
+		handlePipelineErr(c, result.err)
 	} else {
-		c.JSON(http.StatusOK, pl)
+		c.JSON(http.StatusOK, result.pipeline)
 	}
 }
 

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -1,17 +1,3 @@
-// Copyright 2024 Woodpecker Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api_test
 
 import (

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -29,152 +29,125 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/shared/token"
 )
 
-func TestHook(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	_secretService := mocks_secret_service.NewService(t)
-	_registryService := mocks_registry_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 0 // fully synchronous for this test
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-	user := &model.User{
-		ID: 123,
-	}
-	repo := &model.Repo{
-		ID:            123,
-		ForgeRemoteID: "123",
-		Owner:         "owner",
-		Name:          "name",
-		IsActive:      true,
-		UserID:        user.ID,
-		Hash:          "secret-123-this-is-a-secret",
-	}
-	pipeline := &model.Pipeline{
-		ID:     123,
-		RepoID: repo.ID,
-		Event:  model.EventPush,
-	}
-
-	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
-	assert.NoError(t, err)
-
-	header := http.Header{}
-	header.Set("Authorization", fmt.Sprintf("Bearer %s", signedToken))
-	c.Request = &http.Request{
-		Header: header,
-		URL: &url.URL{
-			Scheme: "https",
-		},
-	}
-
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	_forge.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{}, nil)
-	_store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	_manager.On("SecretServiceFromRepo", repo).Return(_secretService)
-	_secretService.On("SecretListPipeline", repo, mock.Anything, mock.Anything).Return(nil, nil)
-	_manager.On("RegistryServiceFromRepo", repo).Return(_registryService)
-	_registryService.On("RegistryListPipeline", repo, mock.Anything).Return(nil, nil)
-	_manager.On("EnvironmentService").Return(nil)
-	_store.On("DeletePipeline", mock.Anything).Return(nil)
-
-	api.PostHook(c)
-
-	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
-	assert.Equal(t, "true", w.Header().Get("Pipeline-Filtered"))
+type hookFixture struct {
+	c              *gin.Context
+	w              *httptest.ResponseRecorder
+	manager        *mocks_services.Manager
+	forge          *mocks_forge.Forge
+	store          *mocks_store.Store
+	configService  *mocks_config_service.Service
+	user           *model.User
+	repo           *model.Repo
+	pipeline       *model.Pipeline
 }
 
-func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+func newHookFixture(t *testing.T, syncTimeout time.Duration) *hookFixture {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 50 * time.Millisecond
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-
-	user := &model.User{ID: 123}
-	repo := &model.Repo{
+	f := &hookFixture{
+		manager:       mocks_services.NewManager(t),
+		forge:         mocks_forge.NewForge(t),
+		store:         mocks_store.NewStore(t),
+		configService: mocks_config_service.NewService(t),
+		w:             httptest.NewRecorder(),
+		user:          &model.User{ID: 123},
+	}
+	f.repo = &model.Repo{
 		ID:            123,
 		ForgeRemoteID: "123",
 		Owner:         "owner",
 		Name:          "name",
 		FullName:      "owner/name",
 		IsActive:      true,
-		UserID:        user.ID,
+		UserID:        f.user.ID,
 		Hash:          "secret-123-this-is-a-secret",
 	}
-	pipeline := &model.Pipeline{
+	f.pipeline = &model.Pipeline{
 		ID:     123,
-		RepoID: repo.ID,
+		RepoID: f.repo.ID,
 		Event:  model.EventPush,
 	}
 
+	server.Config.Services.Manager = f.manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = syncTimeout
+
+	f.c, _ = gin.CreateTestContext(f.w)
+	f.c.Set("store", f.store)
+
 	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	repoToken.Set("repo-id", fmt.Sprintf("%d", f.repo.ID))
+	signedToken, err := repoToken.Sign(f.repo.Hash)
 	require.NoError(t, err)
 
-	c.Request = &http.Request{
+	f.c.Request = &http.Request{
 		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
 		URL:    &url.URL{Scheme: "https"},
 	}
+
+	f.manager.On("ForgeFromRepo", f.repo).Return(f.forge, nil)
+	f.forge.On("Hook", mock.Anything, mock.Anything).Return(f.repo, f.pipeline, nil)
+	f.store.On("GetRepo", f.repo.ID).Return(f.repo, nil)
+	f.store.On("GetUser", f.user.ID).Return(f.user, nil)
+	f.store.On("UpdateRepo", f.repo).Return(nil)
+	f.store.On("CreatePipeline", mock.Anything).Return(nil)
+	f.manager.On("ConfigServiceFromRepo", f.repo).Return(f.configService)
+
+	return f
+}
+
+func (f *hookFixture) expectFilteredCreatePath(t *testing.T) {
+	t.Helper()
+	secretService := mocks_secret_service.NewService(t)
+	registryService := mocks_registry_service.NewService(t)
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	f.forge.On("Netrc", mock.Anything, mock.Anything).Return(&model.Netrc{}, nil)
+	f.store.On("GetPipelineLastBefore", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	f.manager.On("SecretServiceFromRepo", f.repo).Return(secretService)
+	secretService.On("SecretListPipeline", f.repo, mock.Anything, mock.Anything).Return(nil, nil)
+	f.manager.On("RegistryServiceFromRepo", f.repo).Return(registryService)
+	registryService.On("RegistryListPipeline", f.repo, mock.Anything).Return(nil, nil)
+	f.manager.On("EnvironmentService").Return(nil)
+	f.store.On("DeletePipeline", mock.Anything).Return(nil)
+}
+
+func TestHook(t *testing.T) {
+	f := newHookFixture(t, 0) // fully wait for create before responding
+	f.expectFilteredCreatePath(t)
+
+	api.PostHook(f.c)
+
+	assert.Equal(t, http.StatusNoContent, f.c.Writer.Status())
+	assert.Equal(t, "true", f.w.Header().Get("Pipeline-Filtered"))
+}
+
+func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+	f := newHookFixture(t, 50*time.Millisecond)
 
 	var fetchStarted sync.WaitGroup
 	fetchStarted.Add(1)
 	createDone := make(chan struct{})
 
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			fetchStarted.Done()
-			// Block long enough that the sync timeout fires, then finish.
 			time.Sleep(200 * time.Millisecond)
 		}).
 		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
-	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+	f.store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
 		close(createDone)
 	}).Return(nil)
 
 	start := time.Now()
-	api.PostHook(c)
+	api.PostHook(f.c)
 	elapsed := time.Since(start)
 
-	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Equal(t, http.StatusAccepted, f.c.Writer.Status())
 	assert.Less(t, elapsed, 150*time.Millisecond, "handler should return soon after sync timeout")
 
-	// Background create must still run (Fetch was started) and complete.
 	fetchStarted.Wait()
 	select {
 	case <-createDone:
@@ -184,65 +157,19 @@ func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
 }
 
 func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	_manager := mocks_services.NewManager(t)
-	_forge := mocks_forge.NewForge(t)
-	_store := mocks_store.NewStore(t)
-	_configService := mocks_config_service.NewService(t)
-	server.Config.Services.Manager = _manager
-	server.Config.Permissions.Open = true
-	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
-	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
-	server.Config.Server.WebhookSyncTimeout = 30 * time.Millisecond
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Set("store", _store)
-
-	user := &model.User{ID: 123}
-	repo := &model.Repo{
-		ID:            123,
-		ForgeRemoteID: "123",
-		Owner:         "owner",
-		Name:          "name",
-		FullName:      "owner/name",
-		IsActive:      true,
-		UserID:        user.ID,
-		Hash:          "secret-123-this-is-a-secret",
-	}
-	pipeline := &model.Pipeline{
-		ID:     123,
-		RepoID: repo.ID,
-		Event:  model.EventPush,
-	}
-
-	repoToken := token.New(token.HookToken)
-	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
-	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
-	require.NoError(t, err)
+	f := newHookFixture(t, 30*time.Millisecond)
 
 	reqCtx, reqCancel := context.WithCancel(context.Background())
-	c.Request = (&http.Request{
-		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
-		URL:    &url.URL{Scheme: "https"},
-	}).WithContext(reqCtx)
+	f.c.Request = f.c.Request.WithContext(reqCtx)
 
 	var sawLiveCtx sync.WaitGroup
 	sawLiveCtx.Add(1)
 	createDone := make(chan struct{})
 
-	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
-	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
-	_store.On("GetRepo", repo.ID).Return(repo, nil)
-	_store.On("GetUser", user.ID).Return(user, nil)
-	_store.On("UpdateRepo", repo).Return(nil)
-	_store.On("CreatePipeline", mock.Anything).Return(nil)
-	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
-	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			ctx := args.Get(0).(context.Context)
-			reqCancel() // cancel the HTTP request context while Fetch is in flight
+			reqCancel()
 			select {
 			case <-ctx.Done():
 				t.Errorf("background create context was cancelled by request end")
@@ -251,12 +178,12 @@ func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
 			}
 		}).
 		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
-	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+	f.store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
 		close(createDone)
 	}).Return(nil)
 
-	api.PostHook(c)
-	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	api.PostHook(f.c)
+	assert.Equal(t, http.StatusAccepted, f.c.Writer.Status())
 
 	sawLiveCtx.Wait()
 	select {

--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -1,19 +1,38 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/api"
 	mocks_forge "go.woodpecker-ci.org/woodpecker/v3/server/forge/mocks"
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	mocks_config_service "go.woodpecker-ci.org/woodpecker/v3/server/services/config/mocks"
 	mocks_services "go.woodpecker-ci.org/woodpecker/v3/server/services/mocks"
@@ -37,6 +56,7 @@ func TestHook(t *testing.T) {
 	server.Config.Permissions.Open = true
 	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
 	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 0 // fully synchronous for this test
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Set("store", _store)
@@ -93,4 +113,169 @@ func TestHook(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
 	assert.Equal(t, "true", w.Header().Get("Pipeline-Filtered"))
+}
+
+func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	_manager := mocks_services.NewManager(t)
+	_forge := mocks_forge.NewForge(t)
+	_store := mocks_store.NewStore(t)
+	_configService := mocks_config_service.NewService(t)
+	server.Config.Services.Manager = _manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 50 * time.Millisecond
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("store", _store)
+
+	user := &model.User{ID: 123}
+	repo := &model.Repo{
+		ID:            123,
+		ForgeRemoteID: "123",
+		Owner:         "owner",
+		Name:          "name",
+		FullName:      "owner/name",
+		IsActive:      true,
+		UserID:        user.ID,
+		Hash:          "secret-123-this-is-a-secret",
+	}
+	pipeline := &model.Pipeline{
+		ID:     123,
+		RepoID: repo.ID,
+		Event:  model.EventPush,
+	}
+
+	repoToken := token.New(token.HookToken)
+	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
+	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	require.NoError(t, err)
+
+	c.Request = &http.Request{
+		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
+		URL:    &url.URL{Scheme: "https"},
+	}
+
+	var fetchStarted sync.WaitGroup
+	fetchStarted.Add(1)
+	createDone := make(chan struct{})
+
+	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
+	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
+	_store.On("GetRepo", repo.ID).Return(repo, nil)
+	_store.On("GetUser", user.ID).Return(user, nil)
+	_store.On("UpdateRepo", repo).Return(nil)
+	_store.On("CreatePipeline", mock.Anything).Return(nil)
+	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
+	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			fetchStarted.Done()
+			// Block long enough that the sync timeout fires, then finish.
+			time.Sleep(200 * time.Millisecond)
+		}).
+		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
+	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+		close(createDone)
+	}).Return(nil)
+
+	start := time.Now()
+	api.PostHook(c)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Less(t, elapsed, 150*time.Millisecond, "handler should return soon after sync timeout")
+
+	// Background create must still run (Fetch was started) and complete.
+	fetchStarted.Wait()
+	select {
+	case <-createDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background pipeline create did not finish")
+	}
+}
+
+func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	_manager := mocks_services.NewManager(t)
+	_forge := mocks_forge.NewForge(t)
+	_store := mocks_store.NewStore(t)
+	_configService := mocks_config_service.NewService(t)
+	server.Config.Services.Manager = _manager
+	server.Config.Permissions.Open = true
+	server.Config.Permissions.Orgs = permissions.NewOrgs(nil)
+	server.Config.Permissions.Admins = permissions.NewAdmins(nil)
+	server.Config.Server.WebhookSyncTimeout = 30 * time.Millisecond
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("store", _store)
+
+	user := &model.User{ID: 123}
+	repo := &model.Repo{
+		ID:            123,
+		ForgeRemoteID: "123",
+		Owner:         "owner",
+		Name:          "name",
+		FullName:      "owner/name",
+		IsActive:      true,
+		UserID:        user.ID,
+		Hash:          "secret-123-this-is-a-secret",
+	}
+	pipeline := &model.Pipeline{
+		ID:     123,
+		RepoID: repo.ID,
+		Event:  model.EventPush,
+	}
+
+	repoToken := token.New(token.HookToken)
+	repoToken.Set("repo-id", fmt.Sprintf("%d", repo.ID))
+	signedToken, err := repoToken.Sign("secret-123-this-is-a-secret")
+	require.NoError(t, err)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	c.Request = (&http.Request{
+		Header: http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", signedToken)}},
+		URL:    &url.URL{Scheme: "https"},
+	}).WithContext(reqCtx)
+
+	var sawLiveCtx sync.WaitGroup
+	sawLiveCtx.Add(1)
+	createDone := make(chan struct{})
+
+	_manager.On("ForgeFromRepo", repo).Return(_forge, nil)
+	_forge.On("Hook", mock.Anything, mock.Anything).Return(repo, pipeline, nil)
+	_store.On("GetRepo", repo.ID).Return(repo, nil)
+	_store.On("GetUser", user.ID).Return(user, nil)
+	_store.On("UpdateRepo", repo).Return(nil)
+	_store.On("CreatePipeline", mock.Anything).Return(nil)
+	_manager.On("ConfigServiceFromRepo", repo).Return(_configService)
+	_configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			reqCancel() // cancel the HTTP request context while Fetch is in flight
+			select {
+			case <-ctx.Done():
+				t.Errorf("background create context was cancelled by request end")
+			case <-time.After(80 * time.Millisecond):
+				sawLiveCtx.Done()
+			}
+		}).
+		Return(nil, &forge_types.ErrConfigNotFound{Configs: []string{".woodpecker/"}})
+	_store.On("DeletePipeline", mock.Anything).Run(func(args mock.Arguments) {
+		close(createDone)
+	}).Return(nil)
+
+	api.PostHook(c)
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+
+	sawLiveCtx.Wait()
+	select {
+	case <-createDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background pipeline create did not finish")
+	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -53,6 +53,7 @@ var Config = struct {
 		RootPath            string
 		CustomCSSFile       string
 		CustomJsFile        string
+		WebhookSyncTimeout  time.Duration
 	}
 	Agent struct {
 		DisableUserRegisteredAgentRegistration bool

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -268,53 +268,7 @@ func (c *client) File(ctx context.Context, u *model.User, r *model.Repo, b *mode
 }
 
 func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, f string) ([]*forge_types.FileMeta, error) {
-	client := c.newClientToken(ctx, u.AccessToken)
-
-	opts := new(github.RepositoryContentGetOptions)
-	opts.Ref = b.Commit
-	_, data, resp, err := client.Repositories.GetContents(ctx, r.Owner, r.Name, f, opts)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		return nil, errors.Join(err, &forge_types.ErrConfigNotFound{Configs: []string{f}})
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	fc := make(chan *forge_types.FileMeta)
-	errChan := make(chan error)
-
-	for _, file := range data {
-		go func(path string) {
-			content, err := c.File(ctx, u, r, b, path)
-			if err != nil {
-				if errors.Is(err, &forge_types.ErrConfigNotFound{}) {
-					err = fmt.Errorf("git tree reported existence of file but we got: %s", err.Error())
-				}
-				errChan <- err
-			} else {
-				fc <- &forge_types.FileMeta{
-					Name: path,
-					Data: content,
-				}
-			}
-		}(f + "/" + *file.Name)
-	}
-
-	var files []*forge_types.FileMeta
-
-	for i := 0; i < len(data); i++ {
-		select {
-		case err := <-errChan:
-			return nil, err
-		case fileMeta := <-fc:
-			files = append(files, fileMeta)
-		}
-	}
-
-	close(fc)
-	close(errChan)
-
-	return files, nil
+	return c.dirGraphQL(ctx, u.AccessToken, r.Owner, r.Name, b.Commit, f)
 }
 
 func (c *client) PullRequests(ctx context.Context, u *model.User, r *model.Repo, p *model.ListOptions) ([]*model.PullRequest, error) {

--- a/server/forge/github/github.go
+++ b/server/forge/github/github.go
@@ -268,7 +268,7 @@ func (c *client) File(ctx context.Context, u *model.User, r *model.Repo, b *mode
 }
 
 func (c *client) Dir(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, f string) ([]*forge_types.FileMeta, error) {
-	return c.dirGraphQL(ctx, u.AccessToken, r.Owner, r.Name, b.Commit, f)
+	return c.dirGraphQL(ctx, u, r, b, f)
 }
 
 func (c *client) PullRequests(ctx context.Context, u *model.User, r *model.Repo, p *model.ListOptions) ([]*model.PullRequest, error) {

--- a/server/forge/github/graphql.go
+++ b/server/forge/github/graphql.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+)
+
+const dirGraphQLQuery = `
+query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Tree {
+        entries {
+          name
+          type
+          object {
+            ... on Blob {
+              text
+              isBinary
+              isTruncated
+              byteSize
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+type dirGraphQLResponse struct {
+	Data struct {
+		Repository *struct {
+			Object *struct {
+				Entries []struct {
+					Name   string `json:"name"`
+					Type   string `json:"type"`
+					Object *struct {
+						Text         *string `json:"text"`
+						IsBinary     *bool   `json:"isBinary"`
+						IsTruncated  bool    `json:"isTruncated"`
+						ByteSize     int     `json:"byteSize"`
+					} `json:"object"`
+				} `json:"entries"`
+			} `json:"object"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// graphqlEndpoint returns the GraphQL API URL for this forge client.
+// GitHub.com uses https://api.github.com/graphql; GitHub Enterprise uses {url}/api/graphql.
+func (c *client) graphqlEndpoint() string {
+	if c.API == defaultAPI || strings.HasPrefix(c.API, "https://api.github.com") {
+		return "https://api.github.com/graphql"
+	}
+	return strings.TrimSuffix(c.url, "/") + "/api/graphql"
+}
+
+func (c *client) newHTTPClient(ctx context.Context, token string) *http.Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	if c.SkipVerify {
+		tp, _ := tc.Transport.(*oauth2.Transport)
+		tp.Base = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec
+			},
+		}
+	}
+	return tc
+}
+
+// dirGraphQL fetches a single directory level of files via the GitHub GraphQL API,
+// returning blob contents inline to avoid the REST Contents N+1 fan-out.
+func (c *client) dirGraphQL(ctx context.Context, token, owner, name, commit, path string) ([]*forge_types.FileMeta, error) {
+	path = strings.Trim(path, "/")
+	expression := commit + ":" + path
+
+	body, err := json.Marshal(graphqlRequest{
+		Query: dirGraphQLQuery,
+		Variables: map[string]any{
+			"owner":      owner,
+			"name":       name,
+			"expression": expression,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.graphqlEndpoint(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.newHTTPClient(ctx, token).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, &forge_types.ErrConfigNotFound{Configs: []string{path}}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github graphql: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed dirGraphQLResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("github graphql: decode response: %w", err)
+	}
+	if len(parsed.Errors) > 0 {
+		msgs := make([]string, 0, len(parsed.Errors))
+		for _, e := range parsed.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		joined := strings.Join(msgs, "; ")
+		lower := strings.ToLower(joined)
+		if strings.Contains(lower, "could not resolve") || strings.Contains(lower, "not found") {
+			return nil, errors.Join(fmt.Errorf("github graphql: %s", joined), &forge_types.ErrConfigNotFound{Configs: []string{path}})
+		}
+		return nil, fmt.Errorf("github graphql: %s", joined)
+	}
+
+	if parsed.Data.Repository == nil || parsed.Data.Repository.Object == nil {
+		return nil, &forge_types.ErrConfigNotFound{Configs: []string{path}}
+	}
+
+	var files []*forge_types.FileMeta
+	for _, entry := range parsed.Data.Repository.Object.Entries {
+		if entry.Type != "blob" {
+			continue
+		}
+		fullName := path + "/" + entry.Name
+		if entry.Object == nil {
+			return nil, fmt.Errorf("github graphql: missing blob object for %s", fullName)
+		}
+		if entry.Object.IsBinary != nil && *entry.Object.IsBinary {
+			continue
+		}
+		if entry.Object.IsTruncated {
+			return nil, fmt.Errorf("github graphql: blob %s is truncated", fullName)
+		}
+		if entry.Object.Text == nil {
+			return nil, fmt.Errorf("github graphql: blob %s has no text content", fullName)
+		}
+		files = append(files, &forge_types.FileMeta{
+			Name: fullName,
+			Data: []byte(*entry.Object.Text),
+		})
+	}
+
+	return files, nil
+}

--- a/server/forge/github/graphql.go
+++ b/server/forge/github/graphql.go
@@ -17,33 +17,35 @@ package github
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 
-	"golang.org/x/oauth2"
-
 	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 )
 
-const dirGraphQLQuery = `
+const (
+	graphqlErrorTypeNotFound = "NOT_FOUND"
+
+	dirGraphQLQuery = `
 query($owner: String!, $name: String!, $expression: String!) {
   repository(owner: $owner, name: $name) {
     object(expression: $expression) {
       ... on Tree {
         entries {
           name
+          path
           type
           object {
             ... on Blob {
               text
               isBinary
               isTruncated
-              byteSize
             }
           }
         }
@@ -52,71 +54,67 @@ query($owner: String!, $name: String!, $expression: String!) {
   }
 }
 `
+)
 
 type graphqlRequest struct {
 	Query     string         `json:"query"`
 	Variables map[string]any `json:"variables"`
 }
 
+type graphqlError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+type dirBlob struct {
+	Text        *string `json:"text"`
+	IsBinary    *bool   `json:"isBinary"`
+	IsTruncated bool    `json:"isTruncated"`
+}
+
+type dirEntry struct {
+	Name   string   `json:"name"`
+	Path   string   `json:"path"`
+	Type   string   `json:"type"`
+	Object *dirBlob `json:"object"`
+}
+
+type dirTree struct {
+	Entries []dirEntry `json:"entries"`
+}
+
+type dirRepository struct {
+	Object *dirTree `json:"object"`
+}
+
 type dirGraphQLResponse struct {
 	Data struct {
-		Repository *struct {
-			Object *struct {
-				Entries []struct {
-					Name   string `json:"name"`
-					Type   string `json:"type"`
-					Object *struct {
-						Text         *string `json:"text"`
-						IsBinary     *bool   `json:"isBinary"`
-						IsTruncated  bool    `json:"isTruncated"`
-						ByteSize     int     `json:"byteSize"`
-					} `json:"object"`
-				} `json:"entries"`
-			} `json:"object"`
-		} `json:"repository"`
+		Repository *dirRepository `json:"repository"`
 	} `json:"data"`
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+	Errors []graphqlError `json:"errors"`
 }
 
 // graphqlEndpoint returns the GraphQL API URL for this forge client.
 // GitHub.com uses https://api.github.com/graphql; GitHub Enterprise uses {url}/api/graphql.
 func (c *client) graphqlEndpoint() string {
-	if c.API == defaultAPI || strings.HasPrefix(c.API, "https://api.github.com") {
+	if c.url == defaultURL || c.API == defaultAPI {
 		return "https://api.github.com/graphql"
 	}
 	return strings.TrimSuffix(c.url, "/") + "/api/graphql"
 }
 
-func (c *client) newHTTPClient(ctx context.Context, token string) *http.Client {
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-	if c.SkipVerify {
-		tp, _ := tc.Transport.(*oauth2.Transport)
-		tp.Base = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec
-			},
-		}
-	}
-	return tc
-}
-
 // dirGraphQL fetches a single directory level of files via the GitHub GraphQL API,
 // returning blob contents inline to avoid the REST Contents N+1 fan-out.
-func (c *client) dirGraphQL(ctx context.Context, token, owner, name, commit, path string) ([]*forge_types.FileMeta, error) {
-	path = strings.Trim(path, "/")
-	expression := commit + ":" + path
+// Truncated or incomplete blobs fall back to REST File() for that path only.
+func (c *client) dirGraphQL(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, dirPath string) ([]*forge_types.FileMeta, error) {
+	dirPath = strings.Trim(dirPath, "/")
+	expression := b.Commit + ":" + dirPath
 
 	body, err := json.Marshal(graphqlRequest{
 		Query: dirGraphQLQuery,
 		Variables: map[string]any{
-			"owner":      owner,
-			"name":       name,
+			"owner":      r.Owner,
+			"name":       r.Name,
 			"expression": expression,
 		},
 	})
@@ -131,7 +129,7 @@ func (c *client) dirGraphQL(ctx context.Context, token, owner, name, commit, pat
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := c.newHTTPClient(ctx, token).Do(req)
+	resp, err := c.newClientToken(ctx, u.AccessToken).Client().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -141,10 +139,6 @@ func (c *client) dirGraphQL(ctx context.Context, token, owner, name, commit, pat
 	if err != nil {
 		return nil, err
 	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, &forge_types.ErrConfigNotFound{Configs: []string{path}}
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("github graphql: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
@@ -153,46 +147,68 @@ func (c *client) dirGraphQL(ctx context.Context, token, owner, name, commit, pat
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return nil, fmt.Errorf("github graphql: decode response: %w", err)
 	}
-	if len(parsed.Errors) > 0 {
-		msgs := make([]string, 0, len(parsed.Errors))
-		for _, e := range parsed.Errors {
-			msgs = append(msgs, e.Message)
-		}
-		joined := strings.Join(msgs, "; ")
-		lower := strings.ToLower(joined)
-		if strings.Contains(lower, "could not resolve") || strings.Contains(lower, "not found") {
-			return nil, errors.Join(fmt.Errorf("github graphql: %s", joined), &forge_types.ErrConfigNotFound{Configs: []string{path}})
-		}
-		return nil, fmt.Errorf("github graphql: %s", joined)
+	if err := graphQLResponseError(parsed.Errors, dirPath); err != nil {
+		return nil, err
 	}
-
 	if parsed.Data.Repository == nil || parsed.Data.Repository.Object == nil {
-		return nil, &forge_types.ErrConfigNotFound{Configs: []string{path}}
+		return nil, &forge_types.ErrConfigNotFound{Configs: []string{dirPath}}
 	}
 
+	return c.entriesToFileMeta(ctx, u, r, b, dirPath, parsed.Data.Repository.Object.Entries)
+}
+
+func graphQLResponseError(errs []graphqlError, dirPath string) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	msgs := make([]string, 0, len(errs))
+	notFound := false
+	for _, e := range errs {
+		msgs = append(msgs, e.Message)
+		if e.Type == graphqlErrorTypeNotFound {
+			notFound = true
+		}
+	}
+	joined := strings.Join(msgs, "; ")
+	if notFound {
+		return errors.Join(fmt.Errorf("github graphql: %s", joined), &forge_types.ErrConfigNotFound{Configs: []string{dirPath}})
+	}
+	return fmt.Errorf("github graphql: %s", joined)
+}
+
+func entryPath(dirPath string, entry dirEntry) string {
+	if entry.Path != "" {
+		return entry.Path
+	}
+	return path.Join(dirPath, entry.Name)
+}
+
+func (c *client) entriesToFileMeta(ctx context.Context, u *model.User, r *model.Repo, b *model.Pipeline, dirPath string, entries []dirEntry) ([]*forge_types.FileMeta, error) {
 	var files []*forge_types.FileMeta
-	for _, entry := range parsed.Data.Repository.Object.Entries {
+	for _, entry := range entries {
 		if entry.Type != "blob" {
 			continue
 		}
-		fullName := path + "/" + entry.Name
-		if entry.Object == nil {
-			return nil, fmt.Errorf("github graphql: missing blob object for %s", fullName)
-		}
-		if entry.Object.IsBinary != nil && *entry.Object.IsBinary {
+		fullName := entryPath(dirPath, entry)
+		if entry.Object != nil && entry.Object.IsBinary != nil && *entry.Object.IsBinary {
 			continue
 		}
-		if entry.Object.IsTruncated {
-			return nil, fmt.Errorf("github graphql: blob %s is truncated", fullName)
+
+		needsREST := entry.Object == nil || entry.Object.IsTruncated || entry.Object.Text == nil
+		if needsREST {
+			content, err := c.File(ctx, u, r, b, fullName)
+			if err != nil {
+				return nil, fmt.Errorf("github graphql: rest fallback for %s: %w", fullName, err)
+			}
+			files = append(files, &forge_types.FileMeta{Name: fullName, Data: content})
+			continue
 		}
-		if entry.Object.Text == nil {
-			return nil, fmt.Errorf("github graphql: blob %s has no text content", fullName)
-		}
+
 		files = append(files, &forge_types.FileMeta{
 			Name: fullName,
 			Data: []byte(*entry.Object.Text),
 		})
 	}
-
 	return files, nil
 }

--- a/server/forge/github/graphql_test.go
+++ b/server/forge/github/graphql_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	forge_types "go.woodpecker-ci.org/woodpecker/v3/server/forge/types"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+)
+
+func TestGraphQLEndpoint(t *testing.T) {
+	t.Parallel()
+
+	cloud, err := New(Opts{URL: defaultURL})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.github.com/graphql", cloud.(*client).graphqlEndpoint())
+	assert.Equal(t, defaultAPI, cloud.(*client).API)
+
+	ghe, err := New(Opts{URL: "https://ghe.example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://ghe.example.com/api/graphql", ghe.(*client).graphqlEndpoint())
+	assert.Equal(t, "https://ghe.example.com/api/v3/", ghe.(*client).API)
+}
+
+func TestDirGraphQL(t *testing.T) {
+	t.Parallel()
+
+	const yamlA = "steps:\n  - name: a\n    image: alpine\n"
+	const yamlB = "steps:\n  - name: b\n    image: alpine\n"
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/graphql", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "abc123:.woodpecker")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"repository": {
+					"object": {
+						"entries": [
+							{"name": "a.yml", "type": "blob", "object": {"text": ` + jsonString(yamlA) + `, "isBinary": false, "isTruncated": false, "byteSize": 10}},
+							{"name": "b.yaml", "type": "blob", "object": {"text": ` + jsonString(yamlB) + `, "isBinary": false, "isTruncated": false, "byteSize": 10}},
+							{"name": "notes.txt", "type": "blob", "object": {"text": "ignore", "isBinary": false, "isTruncated": false, "byteSize": 6}},
+							{"name": "subdir", "type": "tree", "object": null},
+							{"name": "logo.png", "type": "blob", "object": {"text": null, "isBinary": true, "isTruncated": false, "byteSize": 100}}
+						]
+					}
+				}
+			}
+		}`))
+	}))
+	defer s.Close()
+
+	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	require.NoError(t, err)
+
+	files, err := forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.NoError(t, err)
+
+	byName := map[string]string{}
+	for _, f := range files {
+		byName[f.Name] = string(f.Data)
+	}
+	assert.Equal(t, yamlA, byName[".woodpecker/a.yml"])
+	assert.Equal(t, yamlB, byName[".woodpecker/b.yaml"])
+	assert.Equal(t, "ignore", byName[".woodpecker/notes.txt"])
+	assert.NotContains(t, byName, ".woodpecker/subdir")
+	assert.NotContains(t, byName, ".woodpecker/logo.png")
+}
+
+func TestDirGraphQLMissingTree(t *testing.T) {
+	t.Parallel()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"repository":{"object":null}}}`))
+	}))
+	defer s.Close()
+
+	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	require.NoError(t, err)
+
+	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, &forge_types.ErrConfigNotFound{}))
+}
+
+func TestDirGraphQLTruncatedBlob(t *testing.T) {
+	t.Parallel()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"repository": {
+					"object": {
+						"entries": [
+							{"name": "big.yml", "type": "blob", "object": {"text": "partial", "isBinary": false, "isTruncated": true, "byteSize": 999999}}
+						]
+					}
+				}
+			}
+		}`))
+	}))
+	defer s.Close()
+
+	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	require.NoError(t, err)
+
+	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+func TestDirGraphQLHTTPError(t *testing.T) {
+	t.Parallel()
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer s.Close()
+
+	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	require.NoError(t, err)
+
+	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+}
+
+func jsonString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/server/forge/github/graphql_test.go
+++ b/server/forge/github/graphql_test.go
@@ -16,11 +16,14 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,10 +41,20 @@ func TestGraphQLEndpoint(t *testing.T) {
 	assert.Equal(t, "https://api.github.com/graphql", cloud.(*client).graphqlEndpoint())
 	assert.Equal(t, defaultAPI, cloud.(*client).API)
 
-	ghe, err := New(Opts{URL: "https://ghe.example.com"})
+	ghe, err := New(Opts{URL: "https://ghe.example.com/"})
 	require.NoError(t, err)
 	assert.Equal(t, "https://ghe.example.com/api/graphql", ghe.(*client).graphqlEndpoint())
 	assert.Equal(t, "https://ghe.example.com/api/v3/", ghe.(*client).API)
+}
+
+func withGraphQLServer(t *testing.T, handler http.HandlerFunc) *client {
+	t.Helper()
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+
+	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	require.NoError(t, err)
+	return forge.(*client)
 }
 
 func TestDirGraphQL(t *testing.T) {
@@ -50,7 +63,7 @@ func TestDirGraphQL(t *testing.T) {
 	const yamlA = "steps:\n  - name: a\n    image: alpine\n"
 	const yamlB = "steps:\n  - name: b\n    image: alpine\n"
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/graphql", r.URL.Path)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
@@ -58,6 +71,7 @@ func TestDirGraphQL(t *testing.T) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.Contains(t, string(body), "abc123:.woodpecker")
+		assert.NotContains(t, string(body), "byteSize")
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -65,23 +79,19 @@ func TestDirGraphQL(t *testing.T) {
 				"repository": {
 					"object": {
 						"entries": [
-							{"name": "a.yml", "type": "blob", "object": {"text": ` + jsonString(yamlA) + `, "isBinary": false, "isTruncated": false, "byteSize": 10}},
-							{"name": "b.yaml", "type": "blob", "object": {"text": ` + jsonString(yamlB) + `, "isBinary": false, "isTruncated": false, "byteSize": 10}},
-							{"name": "notes.txt", "type": "blob", "object": {"text": "ignore", "isBinary": false, "isTruncated": false, "byteSize": 6}},
-							{"name": "subdir", "type": "tree", "object": null},
-							{"name": "logo.png", "type": "blob", "object": {"text": null, "isBinary": true, "isTruncated": false, "byteSize": 100}}
+							{"name": "a.yml", "path": ".woodpecker/a.yml", "type": "blob", "object": {"text": ` + jsonString(yamlA) + `, "isBinary": false, "isTruncated": false}},
+							{"name": "b.yaml", "path": ".woodpecker/b.yaml", "type": "blob", "object": {"text": ` + jsonString(yamlB) + `, "isBinary": false, "isTruncated": false}},
+							{"name": "notes.txt", "path": ".woodpecker/notes.txt", "type": "blob", "object": {"text": "ignore", "isBinary": false, "isTruncated": false}},
+							{"name": "subdir", "path": ".woodpecker/subdir", "type": "tree", "object": null},
+							{"name": "logo.png", "path": ".woodpecker/logo.png", "type": "blob", "object": {"text": null, "isBinary": true, "isTruncated": false}}
 						]
 					}
 				}
 			}
 		}`))
-	}))
-	defer s.Close()
+	})
 
-	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
-	require.NoError(t, err)
-
-	files, err := forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	files, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
 	require.NoError(t, err)
 
 	byName := map[string]string{}
@@ -98,60 +108,102 @@ func TestDirGraphQL(t *testing.T) {
 func TestDirGraphQLMissingTree(t *testing.T) {
 	t.Parallel()
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"repository":{"object":null}}}`))
-	}))
-	defer s.Close()
+	})
 
-	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
-	require.NoError(t, err)
-
-	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	_, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, &forge_types.ErrConfigNotFound{}))
 }
 
-func TestDirGraphQLTruncatedBlob(t *testing.T) {
+func TestDirGraphQLNotFoundType(t *testing.T) {
 	t.Parallel()
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"data": {
-				"repository": {
-					"object": {
-						"entries": [
-							{"name": "big.yml", "type": "blob", "object": {"text": "partial", "isBinary": false, "isTruncated": true, "byteSize": 999999}}
-						]
+			"data": {"repository": null},
+			"errors": [{"message": "Could not resolve to a Repository with the name 'o/r'.", "type": "NOT_FOUND"}]
+		}`))
+	})
+
+	_, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, &forge_types.ErrConfigNotFound{}))
+}
+
+func TestDirGraphQLGenericError(t *testing.T) {
+	t.Parallel()
+
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {"repository": null},
+			"errors": [{"message": "API rate limit exceeded", "type": "RATE_LIMITED"}]
+		}`))
+	})
+
+	_, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, &forge_types.ErrConfigNotFound{}))
+	assert.Contains(t, err.Error(), "rate limit")
+}
+
+func TestDirGraphQLTruncatedBlobFallsBackToREST(t *testing.T) {
+	t.Parallel()
+
+	const fullYAML = "steps:\n  - name: big\n    image: alpine\n    commands: [echo hi]\n"
+
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/graphql":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"data": {
+					"repository": {
+						"object": {
+							"entries": [
+								{"name": "big.yml", "path": ".woodpecker/big.yml", "type": "blob", "object": {"text": "partial", "isBinary": false, "isTruncated": true}}
+							]
+						}
 					}
 				}
-			}
-		}`))
-	}))
-	defer s.Close()
+			}`))
+		case strings.Contains(r.URL.Path, "/contents/.woodpecker/big.yml"):
+			encoded := base64.StdEncoding.EncodeToString([]byte(fullYAML))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"name": "big.yml",
+				"path": ".woodpecker/big.yml",
+				"type": "file",
+				"encoding": "base64",
+				"content": %s,
+				"sha": "abc",
+				"size": %d
+			}`, jsonString(encoded+"\n"), len(fullYAML))))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
 
-	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
+	files, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
 	require.NoError(t, err)
-
-	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "truncated")
+	require.Len(t, files, 1)
+	assert.Equal(t, ".woodpecker/big.yml", files[0].Name)
+	assert.Equal(t, fullYAML, string(files[0].Data))
 }
 
 func TestDirGraphQLHTTPError(t *testing.T) {
 	t.Parallel()
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := withGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte("[]"))
-	}))
-	defer s.Close()
+	})
 
-	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
-	require.NoError(t, err)
-
-	_, err = forge.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
+	_, err := c.Dir(context.Background(), &model.User{AccessToken: "token"}, &model.Repo{Owner: "o", Name: "r"}, &model.Pipeline{Commit: "abc123"}, ".woodpecker")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "502")
 }

--- a/server/pipeline/create.go
+++ b/server/pipeline/create.go
@@ -88,7 +88,7 @@ func Create(ctx context.Context, _store store.Store, repo *model.Repo, pipeline 
 		return nil, ErrFiltered
 	} else if configFetchErr != nil {
 		log.Error().Str("repo", repo.FullName).Err(configFetchErr).Msgf("error while fetching config '%s' in '%s' with user: '%s'", repo.Config, pipeline.Ref, repoUser.Login)
-		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", err))
+		return nil, updatePipelineWithErr(ctx, _forge, _store, pipeline, repo, repoUser, fmt.Errorf("could not load config from forge: %w", configFetchErr))
 	}
 
 	pipelineItems, parseErr := parsePipeline(_forge, _store, pipeline, repoUser, repo, forgeYamlConfigs, nil)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace GitHub forge `Dir()` REST Contents N+1 fan-out with a **single GraphQL** tree+blob query (`repository.object(expression: "{sha}:{path}")`).
- Skip non-blob and binary entries; truncated / incomplete blobs **fall back to REST `File()`** for that path only.
- Classify GraphQL failures via structured `errors[].type` (`NOT_FOUND` → `ErrConfigNotFound`); no English-substring matching.
- Reuse `newClientToken(...).Client()` for GraphQL HTTP (no duplicate oauth client).
- `File()` stays on REST for single-file configs.

Stacked on #38 (async webhook ack).