### PR TITLE
fix: resolve server lint and test failures

### DIFF
--- a/server/api/hook_test.go
+++ b/server/api/hook_test.go
@@ -30,15 +30,15 @@ import (
 )
 
 type hookFixture struct {
-	c              *gin.Context
-	w              *httptest.ResponseRecorder
-	manager        *mocks_services.Manager
-	forge          *mocks_forge.Forge
-	store          *mocks_store.Store
-	configService  *mocks_config_service.Service
-	user           *model.User
-	repo           *model.Repo
-	pipeline       *model.Pipeline
+	c             *gin.Context
+	w             *httptest.ResponseRecorder
+	manager       *mocks_services.Manager
+	forge         *mocks_forge.Forge
+	store         *mocks_store.Store
+	configService *mocks_config_service.Service
+	user          *model.User
+	repo          *model.Repo
+	pipeline      *model.Pipeline
 }
 
 func newHookFixture(t *testing.T, syncTimeout time.Duration) *hookFixture {
@@ -159,7 +159,7 @@ func TestHookAsyncAcceptedWhenCreateExceedsSyncTimeout(t *testing.T) {
 func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
 	f := newHookFixture(t, 30*time.Millisecond)
 
-	reqCtx, reqCancel := context.WithCancel(context.Background())
+	reqCtx, reqCancel := context.WithCancelCause(context.Background())
 	f.c.Request = f.c.Request.WithContext(reqCtx)
 
 	var sawLiveCtx sync.WaitGroup
@@ -168,11 +168,12 @@ func TestHookBackgroundCreateIgnoresRequestContextCancel(t *testing.T) {
 
 	f.configService.On("Fetch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			ctx := args.Get(0).(context.Context)
-			reqCancel()
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			reqCancel(nil)
 			select {
 			case <-ctx.Done():
-				t.Errorf("background create context was cancelled by request end")
+				t.Errorf("background create context was canceled by request end")
 			case <-time.After(80 * time.Millisecond):
 				sawLiveCtx.Done()
 			}

--- a/server/forge/bitbucket/convert.go
+++ b/server/forge/bitbucket/convert.go
@@ -227,5 +227,5 @@ func extractEmail(gitAuthor string) (author string) {
 	if len(matches) == 1 {
 		author = matches[0][1]
 	}
-	return
+	return author
 }

--- a/server/forge/gitea/types.go
+++ b/server/forge/gitea/types.go
@@ -36,12 +36,17 @@ type pushHook struct {
 	Sender *gitea.User `json:"sender"`
 }
 
+type pullRequest struct {
+	gitea.PullRequest
+	Draft bool `json:"draft"`
+}
+
 type pullRequestHook struct {
-	Action      string             `json:"action"`
-	Number      int64              `json:"number"`
-	PullRequest *gitea.PullRequest `json:"pull_request"`
-	Repo        *gitea.Repository  `json:"repository"`
-	Sender      *gitea.User        `json:"sender"`
+	Action      string            `json:"action"`
+	Number      int64             `json:"number"`
+	PullRequest *pullRequest      `json:"pull_request"`
+	Repo        *gitea.Repository `json:"repository"`
+	Sender      *gitea.User       `json:"sender"`
 }
 
 type releaseHook struct {

--- a/server/forge/github/graphql_test.go
+++ b/server/forge/github/graphql_test.go
@@ -38,13 +38,17 @@ func TestGraphQLEndpoint(t *testing.T) {
 
 	cloud, err := New(Opts{URL: defaultURL})
 	require.NoError(t, err)
-	assert.Equal(t, "https://api.github.com/graphql", cloud.(*client).graphqlEndpoint())
-	assert.Equal(t, defaultAPI, cloud.(*client).API)
+	cloudClient, ok := cloud.(*client)
+	require.True(t, ok)
+	assert.Equal(t, "https://api.github.com/graphql", cloudClient.graphqlEndpoint())
+	assert.Equal(t, defaultAPI, cloudClient.API)
 
 	ghe, err := New(Opts{URL: "https://ghe.example.com/"})
 	require.NoError(t, err)
-	assert.Equal(t, "https://ghe.example.com/api/graphql", ghe.(*client).graphqlEndpoint())
-	assert.Equal(t, "https://ghe.example.com/api/v3/", ghe.(*client).API)
+	gheClient, ok := ghe.(*client)
+	require.True(t, ok)
+	assert.Equal(t, "https://ghe.example.com/api/graphql", gheClient.graphqlEndpoint())
+	assert.Equal(t, "https://ghe.example.com/api/v3/", gheClient.API)
 }
 
 func withGraphQLServer(t *testing.T, handler http.HandlerFunc) *client {
@@ -54,7 +58,9 @@ func withGraphQLServer(t *testing.T, handler http.HandlerFunc) *client {
 
 	forge, err := New(Opts{URL: s.URL, SkipVerify: true})
 	require.NoError(t, err)
-	return forge.(*client)
+	forgeClient, ok := forge.(*client)
+	require.True(t, ok)
+	return forgeClient
 }
 
 func TestDirGraphQL(t *testing.T) {
@@ -79,8 +85,8 @@ func TestDirGraphQL(t *testing.T) {
 				"repository": {
 					"object": {
 						"entries": [
-							{"name": "a.yml", "path": ".woodpecker/a.yml", "type": "blob", "object": {"text": ` + jsonString(yamlA) + `, "isBinary": false, "isTruncated": false}},
-							{"name": "b.yaml", "path": ".woodpecker/b.yaml", "type": "blob", "object": {"text": ` + jsonString(yamlB) + `, "isBinary": false, "isTruncated": false}},
+							{"name": "a.yml", "path": ".woodpecker/a.yml", "type": "blob", "object": {"text": ` + jsonString(t, yamlA) + `, "isBinary": false, "isTruncated": false}},
+							{"name": "b.yaml", "path": ".woodpecker/b.yaml", "type": "blob", "object": {"text": ` + jsonString(t, yamlB) + `, "isBinary": false, "isTruncated": false}},
 							{"name": "notes.txt", "path": ".woodpecker/notes.txt", "type": "blob", "object": {"text": "ignore", "isBinary": false, "isTruncated": false}},
 							{"name": "subdir", "path": ".woodpecker/subdir", "type": "tree", "object": null},
 							{"name": "logo.png", "path": ".woodpecker/logo.png", "type": "blob", "object": {"text": null, "isBinary": true, "isTruncated": false}}
@@ -174,7 +180,7 @@ func TestDirGraphQLTruncatedBlobFallsBackToREST(t *testing.T) {
 		case strings.Contains(r.URL.Path, "/contents/.woodpecker/big.yml"):
 			encoded := base64.StdEncoding.EncodeToString([]byte(fullYAML))
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{
+			_, _ = fmt.Fprintf(w, `{
 				"name": "big.yml",
 				"path": ".woodpecker/big.yml",
 				"type": "file",
@@ -182,7 +188,7 @@ func TestDirGraphQLTruncatedBlobFallsBackToREST(t *testing.T) {
 				"content": %s,
 				"sha": "abc",
 				"size": %d
-			}`, jsonString(encoded+"\n"), len(fullYAML))))
+			}`, jsonString(t, encoded+"\n"), len(fullYAML))
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -208,10 +214,9 @@ func TestDirGraphQLHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "502")
 }
 
-func jsonString(s string) string {
+func jsonString(t testing.TB, s string) string {
+	t.Helper()
 	b, err := json.Marshal(s)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return string(b)
 }

--- a/server/model/repo.go
+++ b/server/model/repo.go
@@ -91,11 +91,11 @@ func ParseRepo(str string) (user, repo string, err error) {
 	before, after, _ := strings.Cut(str, "/")
 	if before == "" || after == "" {
 		err = fmt.Errorf("invalid or missing repository (e.g. octocat/hello-world)")
-		return
+		return user, repo, err
 	}
 	user = before
 	repo = after
-	return
+	return user, repo, err
 }
 
 // Update updates the repository with values from the given Repo.

--- a/server/model/task.go
+++ b/server/model/task.go
@@ -39,7 +39,7 @@ func (Task) TableName() string {
 
 func (t *Task) String() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s (%s) - %s", t.ID, t.Dependencies, t.DepStatus))
+	fmt.Fprintf(&sb, "%s (%s) - %s", t.ID, t.Dependencies, t.DepStatus)
 	return sb.String()
 }
 

--- a/server/pipeline/queue.go
+++ b/server/pipeline/queue.go
@@ -67,5 +67,5 @@ func taskIDs(dependsOn []string, pipelineItems []*stepbuilder.Item) (taskIDs []s
 			}
 		}
 	}
-	return
+	return taskIDs
 }

--- a/server/store/datastore/engine_test.go
+++ b/server/store/datastore/engine_test.go
@@ -32,7 +32,7 @@ func testDriverConfig() (driver, config string) {
 		driver = os.Getenv("WOODPECKER_DATABASE_DRIVER")
 		config = os.Getenv("WOODPECKER_DATABASE_DATASOURCE")
 	}
-	return
+	return driver, config
 }
 
 // newTestStore creates a new database connection for testing purposes.

--- a/server/store/datastore/migration/migration_test.go
+++ b/server/store/datastore/migration/migration_test.go
@@ -73,7 +73,7 @@ func testDB(t *testing.T, initNewDB bool) (engine *xorm.Engine, closeDB func()) 
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		return
+		return engine, closeDB
 	case "mysql", "postgres":
 		config := os.Getenv("WOODPECKER_DATABASE_DATASOURCE")
 		if !initNewDB {
@@ -84,12 +84,12 @@ func testDB(t *testing.T, initNewDB bool) (engine *xorm.Engine, closeDB func()) 
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		return
+		return engine, closeDB
 	default:
 		t.Errorf("unsupported driver: %s", driver)
 		t.FailNow()
 	}
-	return
+	return engine, closeDB
 }
 
 func TestMigrate(t *testing.T) {


### PR DESCRIPTION
Parse Gitea pull request draft from webhook JSON without relying on SDK fields, and address golangci-lint findings in server tests and helpers.
