### PR TITLE
fix: resolve golangci-lint gofumpt and staticcheck issues

### DIFF
--- a/cli/output/table.go
+++ b/cli/output/table.go
@@ -47,7 +47,7 @@ func (o *Table) Columns() (cols []string) {
 		cols = append(cols, c)
 	}
 	sort.Strings(cols)
-	return
+	return cols
 }
 
 // AddFieldAlias overrides the field name to allow custom column headers.

--- a/pipeline/backend/common/script_posix.go
+++ b/pipeline/backend/common/script_posix.go
@@ -35,11 +35,11 @@ func generateScriptPosix(commands []string, workDir string) string {
 	}
 
 	for _, command := range commands {
-		buf.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&buf,
 			traceScript,
 			shellescape.Quote(command),
 			command,
-		))
+		)
 	}
 
 	return buf.String()

--- a/pipeline/backend/common/script_win.go
+++ b/pipeline/backend/common/script_win.go
@@ -34,11 +34,11 @@ func generateScriptWindows(commands []string, workDir string) string {
 	for _, command := range commands {
 		escaped := fmt.Sprintf("%q", command)
 		escaped = strings.ReplaceAll(escaped, "$", `\$`)
-		buf.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&buf,
 			traceScriptWin,
 			escaped,
 			command,
-		))
+		)
 	}
 
 	return buf.String()

--- a/pipeline/frontend/yaml/linter/linter.go
+++ b/pipeline/frontend/yaml/linter/linter.go
@@ -367,5 +367,5 @@ func (l *Linter) lintBadHabits(config *WorkflowConfig) (err error) {
 		}
 	}
 
-	return
+	return err
 }


### PR DESCRIPTION
## Summary

- Use explicit named returns (`return cols`, `return err`) to satisfy gofumpt `extra-rules`
- Replace `buf.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&buf, ...)` per staticcheck QF1012

## Test plan

- [x] `make lint`
