### PR TITLE
fix(github): trigger pull_request pipeline on ready_for_review

### DIFF
--- a/server/forge/github/parse.go
+++ b/server/forge/github/parse.go
@@ -32,11 +32,12 @@ import (
 const (
 	hookField = "payload"
 
-	actionOpen     = "opened"
-	actionReopen   = "reopened"
-	actionClose    = "closed"
-	actionSync     = "synchronize"
-	actionReleased = "released"
+	actionOpen           = "opened"
+	actionReopen         = "reopened"
+	actionClose          = "closed"
+	actionSync           = "synchronize"
+	actionReadyForReview = "ready_for_review"
+	actionReleased       = "released"
 
 	stateOpen  = "open"
 	stateClose = "closed"
@@ -152,7 +153,8 @@ func parsePullHook(hook *github.PullRequestEvent, merge bool) (*github.PullReque
 	if hook.GetAction() != actionOpen &&
 		hook.GetAction() != actionSync &&
 		hook.GetAction() != actionClose &&
-		hook.GetAction() != actionReopen {
+		hook.GetAction() != actionReopen &&
+		hook.GetAction() != actionReadyForReview {
 		return nil, nil, nil, nil
 	}
 

--- a/server/forge/github/parse_test.go
+++ b/server/forge/github/parse_test.go
@@ -143,6 +143,17 @@ func Test_parseHook(t *testing.T) {
 		assert.True(t, strings.HasPrefix(b.Ref, "refs/tags/"))
 	})
 
+	t.Run("PR ready for review hook", func(t *testing.T) {
+		payload := strings.Replace(fixtures.HookPullRequest, `"action": "opened",`, `"action": "ready_for_review",`, 1)
+		req := testHookRequest([]byte(payload), hookPull)
+		p, r, b, err := parseHook(req, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, r)
+		assert.NotNil(t, b)
+		assert.NotNil(t, p)
+		assert.Equal(t, model.EventPull, b.Event)
+		assert.False(t, b.PullRequestDraft)
+	})
 	t.Run("reopen a pull", func(t *testing.T) {
 		req := testHookRequest([]byte(fixtures.HookPullRequestReopened), hookPull)
 		p, r, b, err := parseHook(req, false)


### PR DESCRIPTION
## Summary
- Handle GitHub `ready_for_review` pull request webhooks as `pull_request` pipelines.
- Our fork is based on Woodpecker 2.7 and predates upstream `pull_request_metadata` support, so these webhooks were previously ignored.

## Why
Marking a draft PR as ready for review did not start CI until a new commit was pushed. This blocks draft-PR CI skipping workflows that rely on `CI_COMMIT_PULL_REQUEST_DRAFT`.

## Test plan
- [ ] `go test ./server/forge/github/... -run Test_parseHook`
- [ ] Deploy to Woodpecker QA/prod
- [ ] Mark a draft PR ready for review without pushing and confirm CI starts


Made with [Cursor](https://cursor.com)